### PR TITLE
Activate PHP 7.1 testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
+    - php: 7.1
     - php: nightly
   allow_failures:
     - php: nightly


### PR DESCRIPTION
`php-nightly` has changed to PHP 7.2, so PHP 7.1 needs to be added to the Travis CI configuration.

As PHP 7.1 is almost released I'm not enabling allowed failure for this version.