### PR TITLE
Add headers implementation to Response

### DIFF
--- a/src/Path/Response/Header.php
+++ b/src/Path/Response/Header.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Path\Response;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface;
+
+/**
+ * Header.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class Header implements HeaderInterface
+{
+    /**
+     * The name of the header.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The definition of the header.
+     *
+     * @var SchemaElementInterface
+     */
+    private $schema;
+
+    /**
+     * Constructs a new Header instance.
+     *
+     * @param string                 $name
+     * @param SchemaElementInterface $schema
+     */
+    public function __construct($name, SchemaElementInterface $schema)
+    {
+        $this->name = $name;
+        $this->schema = $schema;
+    }
+
+    /**
+     * Returns the name of the header.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->schema->jsonSerialize();
+    }
+
+    /**
+     * Returns a new Header instance.
+     *
+     * @param string                 $name
+     * @param SchemaElementInterface $schema
+     *
+     * @return Header
+     */
+    public static function create($name, SchemaElementInterface $schema)
+    {
+        return new self($name, $schema);
+    }
+}

--- a/src/Path/Response/HeaderInterface.php
+++ b/src/Path/Response/HeaderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Path\Response;
+
+use JsonSerializable;
+
+/**
+ * HeaderInterface.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+interface HeaderInterface extends JsonSerializable
+{
+    /**
+     * Returns the name of the header.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/src/Path/Response/Response.php
+++ b/src/Path/Response/Response.php
@@ -29,7 +29,7 @@ class Response implements ResponseInterface
     /**
      * The list of headers that are sent with the response.
      *
-     * @var Header[]
+     * @var HeaderInterface[]
      */
     private $headers = array();
 
@@ -43,7 +43,7 @@ class Response implements ResponseInterface
     /**
      * Constructs a new Response instance.
      *
-     * @param string $description A short description of the response.
+     * @param string $description a short description of the response
      */
     public function __construct($description)
     {
@@ -53,13 +53,27 @@ class Response implements ResponseInterface
     /**
      * Sets the definition of the response structure.
      *
-     * @param SchemaElementInterface $schema A definition of the response structure.
+     * @param SchemaElementInterface $schema a definition of the response structure
      *
      * @return Response
      */
     public function setSchema(SchemaElementInterface $schema)
     {
         $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Adds a header to the list of headers that are sent with the response.
+     *
+     * @param HeaderInterface $header
+     *
+     * @return Response
+     */
+    public function addHeader(HeaderInterface $header)
+    {
+        $this->headers[] = $header;
 
         return $this;
     }
@@ -77,6 +91,12 @@ class Response implements ResponseInterface
         if (isset($this->schema)) {
             $response['schema'] = $this->schema->jsonSerialize();
         }
+        if (empty($this->headers) === false) {
+            $response['headers'] = array();
+            foreach ($this->headers as $header) {
+                $response['headers'][$header->getName()] = $header->jsonSerialize();
+            }
+        }
 
         return $response;
     }
@@ -84,7 +104,7 @@ class Response implements ResponseInterface
     /**
      * Returns a new Response instance.
      *
-     * @param string $description A short description of the response.
+     * @param string $description a short description of the response
      *
      * @return Response
      */

--- a/tests/Path/Response/HeaderTest.php
+++ b/tests/Path/Response/HeaderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Path\Response;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Path\Response\Header;
+use ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * HeaderTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class HeaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The Header instance being tested.
+     *
+     * @var Header
+     */
+    private $header;
+
+    /**
+     * The SchemaElementInterface mock used for testing.
+     *
+     * @var SchemaElementInterface
+     */
+    private $schemaMock;
+
+    /**
+     * Creates a Header instance and mocks for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
+            ->getMock();
+
+        $this->header = new Header('X-Test-Header', $this->schemaMock);
+    }
+
+    /**
+     * Tests if constructing a new Header instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('X-Test-Header', 'name', $this->header);
+        $this->assertAttributeSame($this->schemaMock, 'schema', $this->header);
+    }
+
+    /**
+     * Tests if Header::getName returns the name set during construction.
+     */
+    public function testGetName()
+    {
+        $this->assertSame('X-Test-Header', $this->header->getName());
+    }
+
+    /**
+     * Tests if Header::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $this->schemaMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'description' => 'A description.',
+                    'type' => 'string',
+                )
+            );
+
+        $expectedResult = array(
+            'description' => 'A description.',
+            'type' => 'string',
+        );
+
+        $this->assertEquals($expectedResult, $this->header->jsonSerialize());
+    }
+
+    /**
+     * Tests if Header::jsonSerialize returns the expected JSON encoded result through the json_encode function.
+     */
+    public function testJsonSerializeTroughJsonEncode()
+    {
+        $this->schemaMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'description' => 'A description.',
+                    'type' => 'string',
+                )
+            );
+
+        $expectedResult = '{"description":"A description.","type":"string"}';
+
+        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($this->header));
+    }
+
+    /**
+     * Tests if Header::create returns a new Header instance and sets the instance properties.
+     */
+    public function testCreate()
+    {
+        $header = Header::create('X-Test-Header', $this->schemaMock);
+
+        $this->assertAttributeSame('X-Test-Header', 'name', $header);
+        $this->assertAttributeSame($this->schemaMock, 'schema', $header);
+    }
+}

--- a/tests/Path/Response/ResponseTest.php
+++ b/tests/Path/Response/ResponseTest.php
@@ -50,6 +50,20 @@ class ResponseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Response::addHeader adds the Header instance to the headers instance property and returns the Response instance.
+     */
+    public function testAddHeader()
+    {
+        $headerMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\HeaderInterface')
+            ->getMock();
+
+        $response = $this->response->addHeader($headerMock);
+
+        $this->assertSame($this->response, $response);
+        $this->assertAttributeSame(array($headerMock), 'headers', $this->response);
+    }
+
+    /**
      * Tests if Response::jsonSerialize returns the expected result.
      *
      * @depends testSetSchema
@@ -68,6 +82,52 @@ class ResponseTest extends PHPUnit_Framework_TestCase
             'description' => 'A description.',
             'schema' => array(
                 'type' => 'string',
+            ),
+        );
+
+        $this->assertEquals($expectedResult, $this->response->jsonSerialize());
+    }
+
+    /**
+     * Tests if Response::jsonSerialize returns the expected result with a header set.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeWithHeaders()
+    {
+        $schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
+            ->getMock();
+        $schemaMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('type' => 'string'));
+
+        $headerMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\HeaderInterface')
+            ->getMock();
+        $headerMock->expects($this->once())
+            ->method('getName')
+            ->willReturn('X-Test-Header');
+        $headerMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'description' => 'The header description.',
+                    'type' => 'string',
+                )
+            );
+
+        $this->response->setSchema($schemaMock);
+        $this->response->addHeader($headerMock);
+
+        $expectedResult = array(
+            'description' => 'A description.',
+            'schema' => array(
+                'type' => 'string',
+            ),
+            'headers' => array(
+                'X-Test-Header' => array(
+                    'description' => 'The header description.',
+                    'type' => 'string',
+                ),
             ),
         );
 

--- a/tests/Path/Response/ResponseTest.php
+++ b/tests/Path/Response/ResponseTest.php
@@ -13,13 +13,28 @@ use PHPUnit_Framework_TestCase;
 class ResponseTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * The Response instance being tested.
+     *
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * Creates a Response instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->response = new Response('A description.');
+    }
+
+    /**
      * Tests if constructing a new Response instance sets the instance properties.
      */
     public function testConstruct()
     {
-        $response = new Response('A response description.');
-
-        $this->assertAttributeSame('A response description.', 'description', $response);
+        $this->assertAttributeSame('A description.', 'description', $this->response);
     }
 
     /**
@@ -28,27 +43,26 @@ class ResponseTest extends PHPUnit_Framework_TestCase
     public function testSetSchema()
     {
         $schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
-                ->getMock();
+            ->getMock();
 
-        $response = new Response('');
-
-        $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\Response', $response->setSchema($schemaMock));
-        $this->assertAttributeSame($schemaMock, 'schema', $response);
+        $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\Response', $this->response->setSchema($schemaMock));
+        $this->assertAttributeSame($schemaMock, 'schema', $this->response);
     }
 
     /**
      * Tests if Response::jsonSerialize returns the expected result.
+     *
+     * @depends testSetSchema
      */
     public function testJsonSerialize()
     {
         $schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
-                ->getMock();
+            ->getMock();
         $schemaMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('type' => 'string'));
+            ->method('jsonSerialize')
+            ->willReturn(array('type' => 'string'));
 
-        $response = new Response('A description.');
-        $response->setSchema($schemaMock);
+        $this->response->setSchema($schemaMock);
 
         $expectedResult = array(
             'description' => 'A description.',
@@ -57,7 +71,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->assertEquals($expectedResult, $response->jsonSerialize());
+        $this->assertEquals($expectedResult, $this->response->jsonSerialize());
     }
 
     /**
@@ -66,27 +80,26 @@ class ResponseTest extends PHPUnit_Framework_TestCase
     public function testJsonSerializeThroughJsonEncode()
     {
         $schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
-                ->getMock();
+            ->getMock();
         $schemaMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('type' => 'string'));
+            ->method('jsonSerialize')
+            ->willReturn(array('type' => 'string'));
 
-        $response = new Response('A description.');
-        $response->setSchema($schemaMock);
+        $this->response->setSchema($schemaMock);
 
         $expectedResult = '{"description":"A description.","schema":{"type":"string"}}';
 
-        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($response));
+        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($this->response));
     }
 
     /**
-     * Tests if Specification::create returns a new Specification instance and sets the instance properties.
+     * Tests if Response::create returns a new Response instance and sets the instance properties.
      */
     public function testCreate()
     {
-        $response = Response::create('A response description.');
+        $response = Response::create('A description.');
 
         $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\Response', $response);
-        $this->assertAttributeSame('A response description.', 'description', $response);
+        $this->assertAttributeSame('A description.', 'description', $response);
     }
 }


### PR DESCRIPTION
Adds the headers implementation of the [Swagger / OpenAPI v2 specification](http://swagger.io/specification/#headerObject).

Task of #3.