### PR TITLE
Add examples implementation to Response

### DIFF
--- a/src/Path/Response/Example.php
+++ b/src/Path/Response/Example.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Path\Response;
+
+use InvalidArgumentException;
+
+/**
+ * Example.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class Example implements ExampleInterface
+{
+    /**
+     * The mimetype of the example response.
+     *
+     * @var string
+     */
+    private $mimetype;
+
+    /**
+     * The contents of the example.
+     *
+     * @var array|bool|float|int|string
+     */
+    private $contents;
+
+    /**
+     * Constructs an Example instance.
+     *
+     * @param string                      $mimetype
+     * @param array|bool|float|int|string $contents
+     */
+    public function __construct($mimetype, $contents)
+    {
+        if (is_scalar($contents) === false && is_array($contents) === false) {
+            throw new InvalidArgumentException('Supplied example contents is not of type array, bool, float, int or string.');
+        }
+
+        $this->mimetype = $mimetype;
+        $this->contents = $contents;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMimetype()
+    {
+        return $this->mimetype;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array|bool|float|int|string
+     */
+    public function jsonSerialize()
+    {
+        return $this->contents;
+    }
+}

--- a/src/Path/Response/ExampleInterface.php
+++ b/src/Path/Response/ExampleInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Path\Response;
+
+use JsonSerializable;
+
+/**
+ * ExampleInterface.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+interface ExampleInterface extends JsonSerializable
+{
+    /**
+     * Returns the mimetype of the example.
+     *
+     * @return string
+     */
+    public function getMimetype();
+}

--- a/src/Path/Response/Response.php
+++ b/src/Path/Response/Response.php
@@ -36,7 +36,7 @@ class Response implements ResponseInterface
     /**
      * The examples for operation responses.
      *
-     * @var array
+     * @var ExampleInterface[]
      */
     private $examples = array();
 
@@ -79,6 +79,20 @@ class Response implements ResponseInterface
     }
 
     /**
+     * Adds an example for operation responses.
+     *
+     * @param ExampleInterface $example
+     *
+     * @return Response
+     */
+    public function addExample(ExampleInterface $example)
+    {
+        $this->examples[] = $example;
+
+        return $this;
+    }
+
+    /**
      * Returns the representation of this object for JSON encoding.
      *
      * @return array
@@ -95,6 +109,12 @@ class Response implements ResponseInterface
             $response['headers'] = array();
             foreach ($this->headers as $header) {
                 $response['headers'][$header->getName()] = $header->jsonSerialize();
+            }
+        }
+        if (empty($this->examples) === false) {
+            $response['examples'] = array();
+            foreach ($this->examples as $example) {
+                $response['examples'][$example->getMimetype()] = $example->jsonSerialize();
             }
         }
 

--- a/tests/Path/Response/ExampleTest.php
+++ b/tests/Path/Response/ExampleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Path\Response;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Path\Response\Example;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+/**
+ * ExampleTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ExampleTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The Example instance being tested.
+     *
+     * @var Example
+     */
+    private $example;
+
+    /**
+     * Creates an Example instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->example = new Example(
+            'application/json',
+            array(
+                'foo' => 'bar',
+                'baz' => 'qux',
+            )
+        );
+    }
+
+    /**
+     * Tests if constructing a new Example instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('application/json', 'mimetype', $this->example);
+        $this->assertAttributeSame(
+            array(
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ),
+            'contents',
+            $this->example
+        );
+    }
+
+    /**
+     * Tests if constructing an Example instance with various contents does not throw an InvalidArgumentException.
+     *
+     * @dataProvider provideExampleContents
+     *
+     * @param string $mimetype
+     * @param mixed  $contents
+     */
+    public function testConstructAllowsContents($mimetype, $contents)
+    {
+        $example = new Example($mimetype, $contents);
+
+        $this->assertAttributeSame($contents, 'contents', $example);
+    }
+
+    /**
+     * Tests if constructing an Example instance with invalid contents throws an InvalidArgumentException.
+     */
+    public function testConstructThrowsInvalidArgumentException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Supplied example contents is not of type array, bool, float, int or string.');
+
+        new Example('application/json', new stdClass());
+    }
+
+    /**
+     * Tests if Example::getMimetype returns the mimetype set during construction.
+     */
+    public function testGetMimetype()
+    {
+        $this->assertSame('application/json', $this->example->getMimetype());
+    }
+
+    /**
+     * Tests if Example::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $expectedResult = array(
+            'foo' => 'bar',
+            'baz' => 'qux',
+        );
+
+        $this->assertEquals($expectedResult, $this->example->jsonSerialize());
+    }
+
+    /**
+     * Returns the test cases for @see testConstructAllowsContents.
+     *
+     * @return array
+     */
+    public function provideExampleContents()
+    {
+        return array(
+            array('text/plain', 'String'),
+            array('text/plain', true),
+            array('text/plain', 1),
+            array('text/plain', 1.0),
+            array(
+                'application/json',
+                array(
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ),
+            ),
+        );
+    }
+}

--- a/tests/Path/Response/ResponseTest.php
+++ b/tests/Path/Response/ResponseTest.php
@@ -64,6 +64,20 @@ class ResponseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Response::addExample adds the Example instance to the examples instance property and returns the Response instance.
+     */
+    public function testAddExample()
+    {
+        $exampleMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\ExampleInterface')
+            ->getMock();
+
+        $response = $this->response->addExample($exampleMock);
+
+        $this->assertSame($this->response, $response);
+        $this->assertAttributeSame(array($exampleMock), 'examples', $this->response);
+    }
+
+    /**
      * Tests if Response::jsonSerialize returns the expected result.
      *
      * @depends testSetSchema
@@ -127,6 +141,52 @@ class ResponseTest extends PHPUnit_Framework_TestCase
                 'X-Test-Header' => array(
                     'description' => 'The header description.',
                     'type' => 'string',
+                ),
+            ),
+        );
+
+        $this->assertEquals($expectedResult, $this->response->jsonSerialize());
+    }
+
+    /**
+     * Tests if Response::jsonSerialize returns the expected result with an example set.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeWithExamples()
+    {
+        $schemaMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
+            ->getMock();
+        $schemaMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('type' => 'string'));
+
+        $exampleMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Response\ExampleInterface')
+            ->getMock();
+        $exampleMock->expects($this->once())
+            ->method('getMimetype')
+            ->willReturn('application/json');
+        $exampleMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                )
+            );
+
+        $this->response->setSchema($schemaMock);
+        $this->response->addExample($exampleMock);
+
+        $expectedResult = array(
+            'description' => 'A description.',
+            'schema' => array(
+                'type' => 'string',
+            ),
+            'examples' => array(
+                'application/json' => array(
+                    'foo' => 'bar',
+                    'baz' => 'qux',
                 ),
             ),
         );


### PR DESCRIPTION
Adds the examples implementation of the [Swagger / OpenAPI v2 specification](http://swagger.io/specification/#exampleObject).

Task of #3.