### PR TITLE
Add external documentation implementation

### DIFF
--- a/src/ExternalDocumentation.php
+++ b/src/ExternalDocumentation.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator;
+
+use JsonSerializable;
+
+/**
+ * ExternalDocumentation.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ExternalDocumentation implements JsonSerializable
+{
+    /**
+     * The URL for the target documentation.
+     *
+     * @var string
+     */
+    private $url;
+
+    /**
+     * The description of the target documentation.
+     *
+     * @var string
+     */
+    private $description;
+
+    /**
+     * Constructs a new ExternalDocumentation instance.
+     *
+     * @param string $url         the URL for the target documentation
+     * @param string $description a short description of the target documentation
+     */
+    public function __construct($url, $description = null)
+    {
+        $this->url = $url;
+        $this->description = $description;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $externalDocumentation = array(
+            'url' => $this->url,
+        );
+        if (isset($this->description)) {
+            $externalDocumentation['description'] = $this->description;
+        }
+
+        return $externalDocumentation;
+    }
+}

--- a/src/Path/Operation.php
+++ b/src/Path/Operation.php
@@ -2,6 +2,7 @@
 
 namespace ConnectHolland\OpenAPISpecificationGenerator\Path;
 
+use ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation;
 use ConnectHolland\OpenAPISpecificationGenerator\Parameter\ParameterInterface;
 use JsonSerializable;
 
@@ -159,6 +160,20 @@ class Operation implements JsonSerializable
     }
 
     /**
+     * Sets additional external documentation for this operation.
+     *
+     * @param ExternalDocumentation $externalDocumentation additional external documentation for this operation
+     *
+     * @return Operation
+     */
+    public function setExternalDocumentation(ExternalDocumentation $externalDocumentation)
+    {
+        $this->externalDocumentation = $externalDocumentation;
+
+        return $this;
+    }
+
+    /**
      * Sets the list of MIME types the operation can consume.
      *
      * @param array $consumes
@@ -258,6 +273,9 @@ class Operation implements JsonSerializable
         }
         if (isset($this->description)) {
             $operation['description'] = $this->description;
+        }
+        if (isset($this->externalDocumentation)) {
+            $operation['externalDocs'] = $this->externalDocumentation->jsonSerialize();
         }
         if (empty($this->consumes) === false) {
             $operation['consumes'] = $this->consumes;

--- a/src/Path/Operation.php
+++ b/src/Path/Operation.php
@@ -218,7 +218,7 @@ class Operation implements JsonSerializable
     /**
      * Sets the list of tags for API documentation control.
      *
-     * @param array $tags A list of tags for API documentation control.
+     * @param array $tags a list of tags for API documentation control
      *
      * @return Operation
      */

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -88,7 +88,7 @@ class Specification implements JsonSerializable
     /**
      * Constructs a new Specification instance.
      *
-     * @param Info $info The metadata about the API.
+     * @param Info $info the metadata about the API
      */
     public function __construct(Info $info)
     {
@@ -98,7 +98,7 @@ class Specification implements JsonSerializable
     /**
      * Sets the host (name or ip) serving the API.
      *
-     * @param string $host The host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths. It MAY include a port.
+     * @param string $host the host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths. It MAY include a port.
      *
      * @return Specification
      */
@@ -112,7 +112,7 @@ class Specification implements JsonSerializable
     /**
      * Sets the base path on which the API is served.
      *
-     * @param string $basePath The base path on which the API is served, which is relative to the host.
+     * @param string $basePath the base path on which the API is served, which is relative to the host
      *
      * @return Specification
      */
@@ -126,7 +126,7 @@ class Specification implements JsonSerializable
     /**
      * Sets the transfer protocol of the API.
      *
-     * @param array $schemes The transfer protocol of the API. Values MUST be from the list: "http", "https", "ws", "wss".
+     * @param array $schemes the transfer protocol of the API. Values MUST be from the list: "http", "https", "ws", "wss".
      *
      * @return Specification
      */
@@ -140,7 +140,7 @@ class Specification implements JsonSerializable
     /**
      * Sets the list of MIME types the APIs can consume.
      *
-     * @param array $consumes A list of MIME types the APIs can consume.
+     * @param array $consumes a list of MIME types the APIs can consume
      *
      * @return Specification
      */
@@ -154,7 +154,7 @@ class Specification implements JsonSerializable
     /**
      * Sets the list of MIME types the APIs can produce.
      *
-     * @param array $produces A list of MIME types the APIs can produce.
+     * @param array $produces a list of MIME types the APIs can produce
      *
      * @return Specification
      */
@@ -168,8 +168,8 @@ class Specification implements JsonSerializable
     /**
      * Adds a path endpoint to the specification.
      *
-     * @param string   $path     A relative path to an individual endpoint. The field name MUST begin with a slash.
-     * @param PathItem $pathItem A PathItem instance containing the operations available on the path.
+     * @param string   $path     a relative path to an individual endpoint. The field name MUST begin with a slash.
+     * @param PathItem $pathItem a PathItem instance containing the operations available on the path
      *
      * @return Specification
      */
@@ -183,8 +183,8 @@ class Specification implements JsonSerializable
     /**
      * Adds a single definition.
      *
-     * @param string                 $definition The name of the definition.
-     * @param SchemaElementInterface $schema     A single definition, mapping the "name" to the schema it defines.
+     * @param string                 $definition the name of the definition
+     * @param SchemaElementInterface $schema     a single definition, mapping the "name" to the schema it defines
      *
      * @return Specification
      */

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -79,6 +79,13 @@ class Specification implements JsonSerializable
     private $definitions = array();
 
     /**
+     * Additional external documentation.
+     *
+     * @var ExternalDocumentation
+     */
+    private $externalDocumentation;
+
+    /**
      * Constructs a new Specification instance.
      *
      * @param Info $info The metadata about the API.
@@ -189,6 +196,20 @@ class Specification implements JsonSerializable
     }
 
     /**
+     * Sets the additional external documentation.
+     *
+     * @param ExternalDocumentation $externalDocumentation
+     *
+     * @return Specification
+     */
+    public function setExternalDocumentation(ExternalDocumentation $externalDocumentation)
+    {
+        $this->externalDocumentation = $externalDocumentation;
+
+        return $this;
+    }
+
+    /**
      * Returns the representation of this object for JSON encoding.
      *
      * @return array
@@ -227,6 +248,10 @@ class Specification implements JsonSerializable
             foreach ($this->definitions as $definition => $schema) {
                 $specification['definitions'][$definition] = $schema->jsonSerialize();
             }
+        }
+
+        if (isset($this->externalDocumentation)) {
+            $specification['externalDocs'] = $this->externalDocumentation->jsonSerialize();
         }
 
         return $specification;

--- a/tests/ExternalDocumentationTest.php
+++ b/tests/ExternalDocumentationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test;
+
+use ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * ExternalDocumentationTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ExternalDocumentationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The ExternalDocumentation instance being tested.
+     *
+     * @var ExternalDocumentation
+     */
+    private $externalDocumentation;
+
+    /**
+     * Creates a ExternalDocumentation for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->externalDocumentation = new ExternalDocumentation('https://documentation.connectholland.nl', 'A description');
+    }
+
+    /**
+     * Tests if constructing a new ExternalDocumentation instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('https://documentation.connectholland.nl', 'url', $this->externalDocumentation);
+        $this->assertAttributeSame('A description', 'description', $this->externalDocumentation);
+    }
+
+    /**
+     * Tests if ExternalDocumentation::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $expectedResult = array(
+            'url' => 'https://documentation.connectholland.nl',
+            'description' => 'A description',
+        );
+
+        $this->assertEquals($expectedResult, $this->externalDocumentation->jsonSerialize());
+    }
+}

--- a/tests/Path/OperationTest.php
+++ b/tests/Path/OperationTest.php
@@ -14,17 +14,39 @@ use stdClass;
 class OperationTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * The Operation instance being tested.
+     *
+     * @var Operation
+     */
+    private $operation;
+
+    /**
+     * The Responses instance mock used for testing.
+     *
+     * @var Responses
+     */
+    private $responsesMock;
+
+    /**
+     * Creates a Operation for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->operation = new Operation($this->responsesMock);
+    }
+
+    /**
      * Tests if constructing a new Operation instance sets the instance properties.
      */
     public function testConstruct()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
-
-        $operation = new Operation($responsesMock);
-
-        $this->assertAttributeSame($responsesMock, 'responses', $operation);
+        $this->assertAttributeSame($this->responsesMock, 'responses', $this->operation);
     }
 
     /**
@@ -32,13 +54,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetOperationId()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setOperationId('test-operation');
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setOperationId('test-operation'));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame('test-operation', 'operationId', $operation);
     }
 
@@ -47,13 +65,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetSummary()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setSummary('A summary.');
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setSummary('A summary.'));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame('A summary.', 'summary', $operation);
     }
 
@@ -62,13 +76,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetDescription()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setDescription('A description.');
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setDescription('A description.'));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame('A description.', 'description', $operation);
     }
 
@@ -77,13 +87,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetConsumes()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setConsumes(array('application/json'));
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setConsumes(array('application/json')));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(array('application/json'), 'consumes', $operation);
     }
 
@@ -92,13 +98,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetProduces()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setProduces(array('application/json'));
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setProduces(array('application/json')));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(array('application/json'), 'produces', $operation);
     }
 
@@ -107,13 +109,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetSchemes()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setSchemes(array('https'));
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setSchemes(array('https')));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(array('https'), 'schemes', $operation);
     }
 
@@ -122,13 +120,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetTags()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setTags(array('tag'));
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setTags(array('tag')));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(array('tag'), 'tags', $operation);
     }
 
@@ -137,13 +131,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetDeprecated()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $operation = $this->operation->setDeprecated(true);
 
-        $operation = new Operation($responsesMock);
-
-        $this->assertSame($operation, $operation->setDeprecated(true));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(true, 'deprecated', $operation);
     }
 
@@ -152,16 +142,12 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testAddParameter()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
-
         $parameterMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Parameter\ParameterInterface')
                 ->getMock();
 
-        $operation = new Operation($responsesMock);
+        $operation = $this->operation->addParameter($parameterMock);
 
-        $this->assertSame($operation, $operation->addParameter($parameterMock));
+        $this->assertSame($this->operation, $operation);
         $this->assertAttributeSame(array($parameterMock), 'parameters', $operation);
     }
 
@@ -170,29 +156,25 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testJsonSerialize()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
-        $responsesMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(new stdClass());
+        $this->responsesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
 
         $parameterMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Parameter\ParameterInterface')
-                ->getMock();
+            ->getMock();
         $parameterMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('name' => 'parameterName', 'in' => 'body', 'schema' => array('type' => 'string')));
+            ->method('jsonSerialize')
+            ->willReturn(array('name' => 'parameterName', 'in' => 'body', 'schema' => array('type' => 'string')));
 
-        $operation = new Operation($responsesMock);
-        $operation->setOperationId('test-operation');
-        $operation->setSummary('A summary.');
-        $operation->setDescription('A description.');
-        $operation->setConsumes(array('application/json'));
-        $operation->setProduces(array('application/json'));
-        $operation->setSchemes(array('https'));
-        $operation->setTags(array('tag'));
-        $operation->setDeprecated(true);
-        $operation->addParameter($parameterMock);
+        $this->operation->setOperationId('test-operation');
+        $this->operation->setSummary('A summary.');
+        $this->operation->setDescription('A description.');
+        $this->operation->setConsumes(array('application/json'));
+        $this->operation->setProduces(array('application/json'));
+        $this->operation->setSchemes(array('https'));
+        $this->operation->setTags(array('tag'));
+        $this->operation->setDeprecated(true);
+        $this->operation->addParameter($parameterMock);
 
         $expectedResult = array(
             'operationId' => 'test-operation',
@@ -215,7 +197,7 @@ class OperationTest extends PHPUnit_Framework_TestCase
             'tags' => array('tag'),
         );
 
-        $this->assertEquals($expectedResult, $operation->jsonSerialize());
+        $this->assertEquals($expectedResult, $this->operation->jsonSerialize());
     }
 
     /**
@@ -223,33 +205,29 @@ class OperationTest extends PHPUnit_Framework_TestCase
      */
     public function testJsonSerializeThroughJsonEncode()
     {
-        $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
-        $responsesMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(new stdClass());
+        $this->responsesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
 
         $parameterMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Parameter\ParameterInterface')
-                ->getMock();
+            ->getMock();
         $parameterMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('name' => 'parameterName', 'in' => 'body', 'schema' => array('type' => 'string')));
+            ->method('jsonSerialize')
+            ->willReturn(array('name' => 'parameterName', 'in' => 'body', 'schema' => array('type' => 'string')));
 
-        $operation = new Operation($responsesMock);
-        $operation->setOperationId('test-operation');
-        $operation->setSummary('A summary.');
-        $operation->setDescription('A description.');
-        $operation->setConsumes(array('application/json'));
-        $operation->setProduces(array('application/json'));
-        $operation->setSchemes(array('https'));
-        $operation->setTags(array('tag'));
-        $operation->setDeprecated(true);
-        $operation->addParameter($parameterMock);
+        $this->operation->setOperationId('test-operation');
+        $this->operation->setSummary('A summary.');
+        $this->operation->setDescription('A description.');
+        $this->operation->setConsumes(array('application/json'));
+        $this->operation->setProduces(array('application/json'));
+        $this->operation->setSchemes(array('https'));
+        $this->operation->setTags(array('tag'));
+        $this->operation->setDeprecated(true);
+        $this->operation->addParameter($parameterMock);
 
         $expectedResult = '{"operationId":"test-operation","summary":"A summary.","description":"A description.","consumes":["application\/json"],"produces":["application\/json"],"parameters":[{"name":"parameterName","in":"body","schema":{"type":"string"}}],"responses":{},"schemes":["https"],"deprecated":true,"tags":["tag"]}';
 
-        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($operation));
+        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($this->operation));
     }
 
     /**
@@ -258,8 +236,8 @@ class OperationTest extends PHPUnit_Framework_TestCase
     public function testCreate()
     {
         $responsesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\Responses')
-                ->disableOriginalConstructor()
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $operation = Operation::create($responsesMock);
 

--- a/tests/Path/OperationTest.php
+++ b/tests/Path/OperationTest.php
@@ -83,6 +83,21 @@ class OperationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Operation::setExternalDocumentation sets the instance property and returns the Operation instance.
+     */
+    public function testSetExternalDocumentation()
+    {
+        $externalDocumentationMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $operation = $this->operation->setExternalDocumentation($externalDocumentationMock);
+
+        $this->assertSame($this->operation, $operation);
+        $this->assertAttributeSame($externalDocumentationMock, 'externalDocumentation', $operation);
+    }
+
+    /**
      * Tests if Operation::setConsumes sets the instance property and returns the Operation instance.
      */
     public function testSetConsumes()
@@ -166,6 +181,13 @@ class OperationTest extends PHPUnit_Framework_TestCase
             ->method('jsonSerialize')
             ->willReturn(array('name' => 'parameterName', 'in' => 'body', 'schema' => array('type' => 'string')));
 
+        $externalDocumentationMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $externalDocumentationMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('url' => 'https://documentation.connectholland.nl'));
+
         $this->operation->setOperationId('test-operation');
         $this->operation->setSummary('A summary.');
         $this->operation->setDescription('A description.');
@@ -175,11 +197,15 @@ class OperationTest extends PHPUnit_Framework_TestCase
         $this->operation->setTags(array('tag'));
         $this->operation->setDeprecated(true);
         $this->operation->addParameter($parameterMock);
+        $this->operation->setExternalDocumentation($externalDocumentationMock);
 
         $expectedResult = array(
             'operationId' => 'test-operation',
             'summary' => 'A summary.',
             'description' => 'A description.',
+            'externalDocs' => array(
+                'url' => 'https://documentation.connectholland.nl',
+            ),
             'consumes' => array('application/json'),
             'produces' => array('application/json'),
             'parameters' => array(

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -32,17 +32,39 @@ use stdClass;
 class SpecificationTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * The Specification instance being tested.
+     *
+     * @var Specification
+     */
+    private $specification;
+
+    /**
+     * The Info instance mock for testing.
+     *
+     * @var Info
+     */
+    private $infoMock;
+
+    /**
+     * Creates a Specification instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->specification = new Specification($this->infoMock);
+    }
+
+    /**
      * Tests if constructing a new Specification instance sets the instance properties.
      */
     public function testConstruct()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
-
-        $specification = new Specification($infoMock);
-
-        $this->assertAttributeSame($infoMock, 'info', $specification);
+        $this->assertAttributeSame($this->infoMock, 'info', $this->specification);
     }
 
     /**
@@ -50,13 +72,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetHost()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $specification = $this->specification->setHost('api.example.com');
 
-        $specification = new Specification($infoMock);
-
-        $this->assertSame($specification, $specification->setHost('api.example.com'));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame('api.example.com', 'host', $specification);
     }
 
@@ -65,13 +83,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetBasePath()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $specification = $this->specification->setBasePath('/awesome/api');
 
-        $specification = new Specification($infoMock);
-
-        $this->assertSame($specification, $specification->setBasePath('/awesome/api'));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame('/awesome/api', 'basePath', $specification);
     }
 
@@ -80,13 +94,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetSchemes()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $specification = $this->specification->setSchemes(array('https'));
 
-        $specification = new Specification($infoMock);
-
-        $this->assertSame($specification, $specification->setSchemes(array('https')));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame(array('https'), 'schemes', $specification);
     }
 
@@ -95,13 +105,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetConsumes()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $specification = $this->specification->setConsumes(array('application/json'));
 
-        $specification = new Specification($infoMock);
-
-        $this->assertSame($specification, $specification->setConsumes(array('application/json')));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame(array('application/json'), 'consumes', $specification);
     }
 
@@ -110,13 +116,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetProduces()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $specification = $this->specification->setProduces(array('application/json'));
 
-        $specification = new Specification($infoMock);
-
-        $this->assertSame($specification, $specification->setProduces(array('application/json')));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame(array('application/json'), 'produces', $specification);
     }
 
@@ -125,17 +127,13 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetPath()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
-
         $pathItemMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Path\PathItem')
-                ->disableOriginalConstructor()
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $specification = new Specification($infoMock);
+        $specification = $this->specification->setPath('/path', $pathItemMock);
 
-        $this->assertSame($specification, $specification->setPath('/path', $pathItemMock));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame(array('/path' => $pathItemMock), 'paths', $specification);
     }
 
@@ -144,17 +142,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetDefinition()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
-
         $schemaElementMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface')
-                ->disableOriginalConstructor()
-                ->getMock();
+            ->getMock();
 
-        $specification = new Specification($infoMock);
+        $specification = $this->specification->setDefinition('someObject', $schemaElementMock);
 
-        $this->assertSame($specification, $specification->setDefinition('someObject', $schemaElementMock));
+        $this->assertSame($this->specification, $specification);
         $this->assertAttributeSame(array('someObject' => $schemaElementMock), 'definitions', $specification);
     }
 
@@ -163,14 +156,9 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testJsonSerialize()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
-        $infoMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('title' => 'API', 'version' => '1.0'));
-
-        $specification = new Specification($infoMock);
+        $this->infoMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('title' => 'API', 'version' => '1.0'));
 
         $expectedResult = array(
             'swagger' => '2.0',
@@ -181,7 +169,7 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
             'paths' => new stdClass(),
         );
 
-        $this->assertEquals($expectedResult, $specification->jsonSerialize());
+        $this->assertEquals($expectedResult, $this->specification->jsonSerialize());
     }
 
     /**
@@ -191,18 +179,13 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
      */
     public function testJsonSerializeThroughJsonEncode()
     {
-        $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
-        $infoMock->expects($this->once())
-                ->method('jsonSerialize')
-                ->willReturn(array('title' => 'API', 'version' => '1.0'));
-
-        $specification = new Specification($infoMock);
+        $this->infoMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('title' => 'API', 'version' => '1.0'));
 
         $expectedResult = '{"swagger":"2.0","info":{"title":"API","version":"1.0"},"paths":{}}';
 
-        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($specification));
+        $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($this->specification));
     }
 
     /**
@@ -211,8 +194,8 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     public function testCreate()
     {
         $infoMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Info\Info')
-                ->disableOriginalConstructor()
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $specification = Specification::create($infoMock);
 
@@ -230,15 +213,17 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     public function testJsonSerializeThroughJsonEncodeWithUberAPISpecificationExample()
     {
         $info = Info::create('Uber API', '1.0.0')
-                ->setDescription('Move your app forward with the Uber API');
+            ->setDescription('Move your app forward with the Uber API');
 
         $specification = Specification::create($info)
-                ->setHost('api.uber.com')
-                ->setSchemes(array('https'))
-                ->setBasePath('/v1')
-                ->setProduces(array('application/json'));
+            ->setHost('api.uber.com')
+            ->setSchemes(array('https'))
+            ->setBasePath('/v1')
+            ->setProduces(array('application/json'));
 
-        $specification->setPath('/products', PathItem::create()
+        $specification->setPath(
+            '/products',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -269,9 +254,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                             ->setRequired(true)
                     )
                     ->setTags(array('Products'))
-                ));
+                )
+        );
 
-        $specification->setPath('/estimates/price', PathItem::create()
+        $specification->setPath(
+            '/estimates/price',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -312,9 +300,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                             ->setRequired(true)
                     )
                     ->setTags(array('Estimates'))
-                ));
+                )
+        );
 
-        $specification->setPath('/estimates/time', PathItem::create()
+        $specification->setPath(
+            '/estimates/time',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -355,9 +346,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                             ->setDescription('Unique identifier representing a specific product for a given latitude & longitude.')
                     )
                     ->setTags(array('Estimates'))
-                ));
+                )
+        );
 
-        $specification->setPath('/me', PathItem::create()
+        $specification->setPath(
+            '/me',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -378,9 +372,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                     ->setSummary('User Profile')
                     ->setDescription('The User Profile endpoint returns information about the Uber user that has authorized with the application.')
                     ->setTags(array('User'))
-                ));
+                )
+        );
 
-        $specification->setPath('/history', PathItem::create()
+        $specification->setPath(
+            '/history',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -409,104 +406,111 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                             ->setDescription('Number of items to retrieve. Default is 5, maximum is 100.')
                     )
                     ->setTags(array('User'))
-                ));
+                )
+        );
 
-        $specification->setDefinition('Product',
-                ObjectElement::create()
-                    ->addProperty('product_id', StringElement::create()
-                        ->setDescription('Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.')
-                    )
-                    ->addProperty('description', StringElement::create()
-                        ->setDescription('Description of product.')
-                    )
-                    ->addProperty('display_name', StringElement::create()
-                        ->setDescription('Display name of product.')
-                    )
-                    ->addProperty('capacity', StringElement::create()
-                        ->setDescription('Capacity of product. For example, 4 people.')
-                    )
-                    ->addProperty('image', StringElement::create()
-                        ->setDescription('Image URL representing the product.')
-                    )
-            );
+        $specification->setDefinition(
+            'Product',
+            ObjectElement::create()
+                ->addProperty('product_id', StringElement::create()
+                    ->setDescription('Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.')
+                )
+                ->addProperty('description', StringElement::create()
+                    ->setDescription('Description of product.')
+                )
+                ->addProperty('display_name', StringElement::create()
+                    ->setDescription('Display name of product.')
+                )
+                ->addProperty('capacity', StringElement::create()
+                    ->setDescription('Capacity of product. For example, 4 people.')
+                )
+                ->addProperty('image', StringElement::create()
+                    ->setDescription('Image URL representing the product.')
+                )
+        );
 
-        $specification->setDefinition('PriceEstimate',
-                ObjectElement::create()
-                    ->addProperty('product_id', StringElement::create()
-                        ->setDescription('Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.')
-                    )
-                    ->addProperty('currency_code', StringElement::create()
-                        ->setDescription('[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.')
-                    )
-                    ->addProperty('display_name', StringElement::create()
-                        ->setDescription('Display name of product.')
-                    )
-                    ->addProperty('estimate', StringElement::create()
-                        ->setDescription('Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.')
-                    )
-                    ->addProperty('low_estimate', DoubleElement::create()
-                            ->setFormat(null)
-                        ->setDescription('Lower bound of the estimated price.')
-                    )
-                    ->addProperty('high_estimate', DoubleElement::create()
-                            ->setFormat(null)
-                        ->setDescription('Upper bound of the estimated price.')
-                    )
-                    ->addProperty('surge_multiplier', DoubleElement::create()
-                            ->setFormat(null)
-                        ->setDescription('Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.')
-                    )
-            );
+        $specification->setDefinition(
+            'PriceEstimate',
+            ObjectElement::create()
+                ->addProperty('product_id', StringElement::create()
+                    ->setDescription('Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.')
+                )
+                ->addProperty('currency_code', StringElement::create()
+                    ->setDescription('[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.')
+                )
+                ->addProperty('display_name', StringElement::create()
+                    ->setDescription('Display name of product.')
+                )
+                ->addProperty('estimate', StringElement::create()
+                    ->setDescription('Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.')
+                )
+                ->addProperty('low_estimate', DoubleElement::create()
+                        ->setFormat(null)
+                    ->setDescription('Lower bound of the estimated price.')
+                )
+                ->addProperty('high_estimate', DoubleElement::create()
+                        ->setFormat(null)
+                    ->setDescription('Upper bound of the estimated price.')
+                )
+                ->addProperty('surge_multiplier', DoubleElement::create()
+                        ->setFormat(null)
+                    ->setDescription('Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.')
+                )
+        );
 
-        $specification->setDefinition('Profile',
-                ObjectElement::create()
-                    ->addProperty('first_name', StringElement::create()
-                        ->setDescription('First name of the Uber user.')
-                    )
-                    ->addProperty('last_name', StringElement::create()
-                        ->setDescription('Last name of the Uber user.')
-                    )
-                    ->addProperty('email', StringElement::create()
-                        ->setDescription('Email address of the Uber user')
-                    )
-                    ->addProperty('picture', StringElement::create()
-                        ->setDescription('Image URL of the Uber user.')
-                    )
-                    ->addProperty('promo_code', StringElement::create()
-                        ->setDescription('Promo code of the Uber user.')
-                    )
-            );
+        $specification->setDefinition(
+            'Profile',
+            ObjectElement::create()
+                ->addProperty('first_name', StringElement::create()
+                    ->setDescription('First name of the Uber user.')
+                )
+                ->addProperty('last_name', StringElement::create()
+                    ->setDescription('Last name of the Uber user.')
+                )
+                ->addProperty('email', StringElement::create()
+                    ->setDescription('Email address of the Uber user')
+                )
+                ->addProperty('picture', StringElement::create()
+                    ->setDescription('Image URL of the Uber user.')
+                )
+                ->addProperty('promo_code', StringElement::create()
+                    ->setDescription('Promo code of the Uber user.')
+                )
+        );
 
-        $specification->setDefinition('Activity',
-                ObjectElement::create()
-                    ->addProperty('uuid', StringElement::create()
-                        ->setDescription('Unique identifier for the activity')
-                    )
-            );
+        $specification->setDefinition(
+            'Activity',
+            ObjectElement::create()
+                ->addProperty('uuid', StringElement::create()
+                    ->setDescription('Unique identifier for the activity')
+                )
+        );
 
-        $specification->setDefinition('Activities',
-                ObjectElement::create()
-                    ->addProperty('offset', IntegerElement::create()
-                        ->setDescription('Position in pagination.')
-                    )
-                    ->addProperty('limit', IntegerElement::create()
-                        ->setDescription('Number of items to retrieve (100 max).')
-                    )
-                    ->addProperty('count', IntegerElement::create()
-                        ->setDescription('Total number of items available.')
-                    )
-                    ->addProperty('history', ArrayElement::create()
-                        ->setItems(ReferenceElement::create('Activity'))
-                        ->setDescription('Total number of items available.')
-                    )
-            );
+        $specification->setDefinition(
+            'Activities',
+            ObjectElement::create()
+                ->addProperty('offset', IntegerElement::create()
+                    ->setDescription('Position in pagination.')
+                )
+                ->addProperty('limit', IntegerElement::create()
+                    ->setDescription('Number of items to retrieve (100 max).')
+                )
+                ->addProperty('count', IntegerElement::create()
+                    ->setDescription('Total number of items available.')
+                )
+                ->addProperty('history', ArrayElement::create()
+                    ->setItems(ReferenceElement::create('Activity'))
+                    ->setDescription('Total number of items available.')
+                )
+        );
 
-        $specification->setDefinition('Error',
-                ObjectElement::create()
-                    ->addProperty('code', IntegerElement::create())
-                    ->addProperty('message', StringElement::create())
-                    ->addProperty('fields', StringElement::create())
-            );
+        $specification->setDefinition(
+            'Error',
+            ObjectElement::create()
+                ->addProperty('code', IntegerElement::create())
+                ->addProperty('message', StringElement::create())
+                ->addProperty('fields', StringElement::create())
+        );
 
         $this->assertJsonStringEqualsJsonFile(__DIR__.'/fixtures/uber-api-swagger.json', json_encode($specification, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
@@ -521,14 +525,16 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     public function testJsonSerializeThroughJsonEncodeWithEchoSpecificationExample()
     {
         $info = Info::create('Echo', '1.0.0')
-                ->setDescription("#### Echos back every URL, method, parameter and header\nFeel free to make a path or an operation and use **Try Operation** to test it. The echo server will\nrender back everything.\n");
+            ->setDescription("#### Echos back every URL, method, parameter and header\nFeel free to make a path or an operation and use **Try Operation** to test it. The echo server will\nrender back everything.\n");
 
         $specification = Specification::create($info)
-                ->setHost('mazimi-prod.apigee.net')
-                ->setSchemes(array('http'))
-                ->setBasePath('/echo');
+            ->setHost('mazimi-prod.apigee.net')
+            ->setSchemes(array('http'))
+            ->setBasePath('/echo');
 
-        $specification->setPath('/', PathItem::create()
+        $specification->setPath(
+            '/',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -548,10 +554,14 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                         FormDataParameter::create('year', StringElement::create())
                             ->setDescription('year')
                     )
-                ));
+                )
+        );
 
-        $specification->setPath('/test-path/{id}', PathItem::create()
-                ->setGet(Operation::create(
+        $specification->setPath(
+            '/test-path/{id}',
+            PathItem::create()
+                ->setGet(
+                    Operation::create(
                         Responses::create()
                             ->setResponse(Response::HTTP_OK, Response::create('Echo test-path'))
                     )
@@ -561,7 +571,7 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                         PathParameter::create('id', StringElement::create())->setDescription('ID'),
                     )
                 )
-            );
+        );
 
         $this->assertJsonStringEqualsJsonFile(__DIR__.'/fixtures/echo-swagger.json', json_encode($specification, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
@@ -576,19 +586,21 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     public function testJsonSerializeThroughJsonEncodeWithPetstoreSimpleSpecificationExample()
     {
         $info = Info::create('Swagger Petstore (Simple)', '1.0.0')
-                ->setDescription('A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification')
-                ->setTermsOfService('http://helloreverb.com/terms/')
-                ->setContact(Contact::create('Swagger API team', 'http://swagger.io', 'foo@example.com'))
-                ->setLicense(License::create('MIT', 'http://opensource.org/licenses/MIT'));
+            ->setDescription('A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification')
+            ->setTermsOfService('http://helloreverb.com/terms/')
+            ->setContact(Contact::create('Swagger API team', 'http://swagger.io', 'foo@example.com'))
+            ->setLicense(License::create('MIT', 'http://opensource.org/licenses/MIT'));
 
         $specification = Specification::create($info)
-                ->setHost('petstore.swagger.io')
-                ->setSchemes(array('http'))
-                ->setBasePath('/api')
-                ->setConsumes(array('application/json'))
-                ->setProduces(array('application/json'));
+            ->setHost('petstore.swagger.io')
+            ->setSchemes(array('http'))
+            ->setBasePath('/api')
+            ->setConsumes(array('application/json'))
+            ->setProduces(array('application/json'));
 
-        $specification->setPath('/pets', PathItem::create()
+        $specification->setPath(
+            '/pets',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -640,9 +652,12 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                             ->setDescription('Pet to add to the store')
                             ->setRequired(true)
                     )
-                ));
+                )
+        );
 
-        $specification->setPath('/pets/{id}', PathItem::create()
+        $specification->setPath(
+            '/pets/{id}',
+            PathItem::create()
                 ->setGet(
                     Operation::create(
                         Responses::create()
@@ -685,37 +700,41 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                         PathParameter::create('id', LongElement::create('newPet'))
                             ->setDescription('ID of pet to delete')
                     )
-                ));
+                )
+        );
 
-        $specification->setDefinition('pet',
-                ObjectElement::create()
-                    ->addProperty('id', LongElement::create()
-                        ->setRequired(true)
-                    )
-                    ->addProperty('name', StringElement::create()
-                        ->setRequired(true)
-                    )
-                    ->addProperty('tag', StringElement::create())
-            );
+        $specification->setDefinition(
+            'pet',
+            ObjectElement::create()
+                ->addProperty('id', LongElement::create()
+                    ->setRequired(true)
+                )
+                ->addProperty('name', StringElement::create()
+                    ->setRequired(true)
+                )
+                ->addProperty('tag', StringElement::create())
+        );
 
-        $specification->setDefinition('newPet',
-                ObjectElement::create()
-                    ->addProperty('id', LongElement::create())
-                    ->addProperty('name', StringElement::create()
-                        ->setRequired(true)
-                    )
-                    ->addProperty('tag', StringElement::create())
-            );
+        $specification->setDefinition(
+            'newPet',
+            ObjectElement::create()
+                ->addProperty('id', LongElement::create())
+                ->addProperty('name', StringElement::create()
+                    ->setRequired(true)
+                )
+                ->addProperty('tag', StringElement::create())
+        );
 
-        $specification->setDefinition('errorModel',
-                ObjectElement::create()
-                    ->addProperty('code', IntegerElement::create()
-                        ->setRequired(true)
-                    )
-                    ->addProperty('message', StringElement::create()
-                        ->setRequired(true)
-                    )
-            );
+        $specification->setDefinition(
+            'errorModel',
+            ObjectElement::create()
+                ->addProperty('code', IntegerElement::create()
+                    ->setRequired(true)
+                )
+                ->addProperty('message', StringElement::create()
+                    ->setRequired(true)
+                )
+        );
 
         $this->assertJsonStringEqualsJsonFile(__DIR__.'/fixtures/petstore-simple-swagger.json', json_encode($specification, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -254,7 +254,7 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     /**
      * Tests if Specification::jsonSerialize returns the expected JSON encoded result through the json_encode function with the Uber API specification example.
      *
-     * @link http://editor.swagger.io/ The editor containing the specification example
+     * @see http://editor.swagger.io/ The editor containing the specification example
      *
      * @depends testJsonSerializeThroughJsonEncode
      */
@@ -566,7 +566,7 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     /**
      * Tests if Specification::jsonSerialize returns the expected JSON encoded result through the json_encode function with the Echo specification example.
      *
-     * @link http://editor.swagger.io/ The editor containing the specification example
+     * @see http://editor.swagger.io/ The editor containing the specification example
      *
      * @depends testJsonSerializeThroughJsonEncode
      */
@@ -627,7 +627,7 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     /**
      * Tests if Specification::jsonSerialize returns the expected JSON encoded result through the json_encode function with the Petstore (Simple) specification example.
      *
-     * @link http://editor.swagger.io/ The editor containing the specification example
+     * @see http://editor.swagger.io/ The editor containing the specification example
      *
      * @depends testJsonSerializeThroughJsonEncode
      */

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -152,6 +152,21 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Specification::setExternalDocumentation sets the ExternalDocumentation instance on instance property and returns the Specification instance.
+     */
+    public function testSetExternalDocumentation()
+    {
+        $externalDocumentationMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $specification = $this->specification->setExternalDocumentation($externalDocumentationMock);
+
+        $this->assertSame($this->specification, $specification);
+        $this->assertAttributeSame($externalDocumentationMock, 'externalDocumentation', $specification);
+    }
+
+    /**
      * Tests if Specification::jsonSerialize returns the expected result.
      */
     public function testJsonSerialize()
@@ -167,6 +182,39 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                 'version' => '1.0',
             ),
             'paths' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $this->specification->jsonSerialize());
+    }
+
+    /**
+     * Tests if Specification::jsonSerialize with ExternalDocumentation instance added returns the expected result.
+     */
+    public function testJsonSerializeWithExternalDocumentation()
+    {
+        $this->infoMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('title' => 'API', 'version' => '1.0'));
+
+        $externalDocumentationMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\ExternalDocumentation')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $externalDocumentationMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('url' => 'https://documentation.connectholland.nl'));
+
+        $this->specification->setExternalDocumentation($externalDocumentationMock);
+
+        $expectedResult = array(
+            'swagger' => '2.0',
+            'info' => array(
+                'title' => 'API',
+                'version' => '1.0',
+            ),
+            'paths' => new stdClass(),
+            'externalDocs' => array(
+                'url' => 'https://documentation.connectholland.nl',
+            ),
         );
 
         $this->assertEquals($expectedResult, $this->specification->jsonSerialize());


### PR DESCRIPTION
Adds the examples implementation of the [Swagger / OpenAPI v2 specification](http://swagger.io/specification/#externalDocumentationObject).

Task of #3.