### PR TITLE
Add security implementation

### DIFF
--- a/src/Path/Operation.php
+++ b/src/Path/Operation.php
@@ -93,9 +93,9 @@ class Operation implements JsonSerializable
     /**
      * A declaration of which security schemes are applied for this operation.
      *
-     * @var SecurityRequirement
+     * @var SecurityRequirement[]
      */
-    private $security;
+    private $securityRequirements;
 
     /**
      * Constructs a new Operation instance.
@@ -244,6 +244,25 @@ class Operation implements JsonSerializable
     }
 
     /**
+     * A declaration of which security schemes are applied for this operation.
+     * The list of values describes alternative security schemes that can be
+     * used (that is, there is a logical OR between the security requirements).
+     *
+     * This definition overrides any declared top-level security.
+     * To remove a top-level security declaration, an empty array can be used.
+     *
+     * @param SecurityRequirement[] $securityRequirements
+     *
+     * @return Operation
+     */
+    public function setSecurityRequirements(array $securityRequirements)
+    {
+        $this->securityRequirements = $securityRequirements;
+
+        return $this;
+    }
+
+    /**
      * Adds a parameter applicable for this operation.
      *
      * @param ParameterInterface $parameter
@@ -298,6 +317,12 @@ class Operation implements JsonSerializable
         }
         if (empty($this->tags) === false) {
             $operation['tags'] = $this->tags;
+        }
+        if (isset($this->securityRequirements)) {
+            $operation['security'] = array();
+            foreach ($this->securityRequirements as $securityRequirement) {
+                $operation['security'][] = $securityRequirement->jsonSerialize();
+            }
         }
 
         return $operation;

--- a/src/Security/AbstractSecurityScheme.php
+++ b/src/Security/AbstractSecurityScheme.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+/**
+ * AbstractSecurityScheme.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+abstract class AbstractSecurityScheme implements SecuritySchemeInterface
+{
+    /**
+     * The identifier name for the security scheme.
+     *
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * The type of the security scheme.
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
+     * The short description for security scheme.
+     *
+     * @var string
+     */
+    private $description;
+
+    /**
+     * Constructs a new security scheme instance.
+     *
+     * @param string $identifier the identifier name for the security scheme
+     * @param string $type       the type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+     */
+    public function __construct($identifier, $type)
+    {
+        $this->identifier = $identifier;
+        $this->type = $type;
+    }
+
+    /**
+     * Returns the identifier name for the security scheme.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Sets a short description for the security scheme.
+     *
+     * @param string $description
+     *
+     * @return static
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $securityScheme = array(
+            'type' => $this->type,
+        );
+
+        if (isset($this->description)) {
+            $securityScheme['description'] = $this->description;
+        }
+
+        return $securityScheme;
+    }
+}

--- a/src/Security/ApiKeySecurityScheme.php
+++ b/src/Security/ApiKeySecurityScheme.php
@@ -69,4 +69,18 @@ class ApiKeySecurityScheme extends AbstractSecurityScheme
 
         return $securityScheme;
     }
+
+    /**
+     * Returns a new ApiKeySecurityScheme instance.
+     *
+     * @param string $identifier the identifier name for the security scheme
+     * @param string $name       the name of the header or query parameter to be used
+     * @param string $in         the location of the API key. Valid values are "query" or "header".
+     *
+     * @return ApiKeySecurityScheme
+     */
+    public static function create($identifier, $name, $in)
+    {
+        return new self($identifier, $name, $in);
+    }
 }

--- a/src/Security/ApiKeySecurityScheme.php
+++ b/src/Security/ApiKeySecurityScheme.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+use InvalidArgumentException;
+
+/**
+ * ApiKeySecurityScheme.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ApiKeySecurityScheme extends AbstractSecurityScheme
+{
+    /**
+     * @var string
+     */
+    const IN_QUERY = 'query';
+
+    /**
+     * @var string
+     */
+    const IN_HEADER = 'header';
+
+    /**
+     * The name of the header or query parameter to be used.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The location of the API key.
+     *
+     * @var string
+     */
+    private $in;
+
+    /**
+     * Constructs a new ApiKeySecurityScheme instance.
+     *
+     * @param string $identifier the identifier name for the security scheme
+     * @param string $name       the name of the header or query parameter to be used
+     * @param string $in         the location of the API key. Valid values are "query" or "header".
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($identifier, $name, $in)
+    {
+        if (in_array($in, array(self::IN_QUERY, self::IN_HEADER)) === false) {
+            throw new InvalidArgumentException('Supplied SecurityScheme $in is not of type query or header.');
+        }
+
+        parent::__construct($identifier, self::TYPE_API_KEY);
+
+        $this->name = $name;
+        $this->in = $in;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $securityScheme = parent::jsonSerialize();
+        $securityScheme['name'] = $this->name;
+        $securityScheme['in'] = $this->in;
+
+        return $securityScheme;
+    }
+}

--- a/src/Security/BasicSecurityScheme.php
+++ b/src/Security/BasicSecurityScheme.php
@@ -18,4 +18,16 @@ class BasicSecurityScheme extends AbstractSecurityScheme
     {
         parent::__construct($identifier, self::TYPE_BASIC);
     }
+
+    /**
+     * Returns a new BasicSecurityScheme instance.
+     *
+     * @param string $identifier the identifier name for the security scheme
+     *
+     * @return BasicSecurityScheme
+     */
+    public static function create($identifier)
+    {
+        return new self($identifier);
+    }
 }

--- a/src/Security/BasicSecurityScheme.php
+++ b/src/Security/BasicSecurityScheme.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+/**
+ * BasicSecurityScheme.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class BasicSecurityScheme extends AbstractSecurityScheme
+{
+    /**
+     * Constructs a new BasicSecurityScheme instance.
+     *
+     * @param string $identifier the identifier name for the security scheme
+     */
+    public function __construct($identifier)
+    {
+        parent::__construct($identifier, self::TYPE_BASIC);
+    }
+}

--- a/src/Security/OAuth2SecurityScheme.php
+++ b/src/Security/OAuth2SecurityScheme.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+use InvalidArgumentException;
+
+/**
+ * OAuth2SecurityScheme.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class OAuth2SecurityScheme extends AbstractSecurityScheme
+{
+    /**
+     * @var string
+     */
+    const FLOW_IMPLICIT = 'implicit';
+
+    /**
+     * @var string
+     */
+    const FLOW_PASSWORD = 'password';
+
+    /**
+     * @var string
+     */
+    const FLOW_APPLICATION = 'application';
+
+    /**
+     * @var string
+     */
+    const FLOW_ACCESS_CODE = 'accessCode';
+
+    /**
+     * The flow used by the OAuth2 security scheme.
+     *
+     * @var string
+     */
+    private $flow;
+
+    /**
+     * The authorization URL to be used for this flow.
+     *
+     * @var string|null
+     */
+    private $authorizationUrl;
+
+    /**
+     * The token URL to be used for this flow.
+     *
+     * @var string|null
+     */
+    private $tokenUrl;
+
+    /**
+     * The available scopes for the OAuth2 security scheme.
+     *
+     * @var Scopes
+     */
+    private $scopes;
+
+    /**
+     * Constructs a new OAuth2SecurityScheme instance.
+     *
+     * @param string      $identifier       the identifier name for the security scheme
+     * @param string      $flow             the flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+     * @param string|null $authorizationUrl the authorization URL to be used for this flow. This SHOULD be in the form of a URL.
+     * @param string|null $tokenUrl         the token URL to be used for this flow. This SHOULD be in the form of a URL.
+     * @param Scopes      $scopes           the available scopes for the OAuth2 security scheme
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($identifier, $flow, $authorizationUrl, $tokenUrl, Scopes $scopes)
+    {
+        if (in_array($flow, array(self::FLOW_IMPLICIT, self::FLOW_PASSWORD, self::FLOW_APPLICATION, self::FLOW_ACCESS_CODE)) === false) {
+            throw new InvalidArgumentException('Supplied SecurityScheme flow is not of type implicit, password, application or accessCode.');
+        }
+
+        if (in_array($flow, array(self::FLOW_IMPLICIT, self::FLOW_ACCESS_CODE)) && isset($authorizationUrl) === false) {
+            throw new InvalidArgumentException('The authorizationUrl is required for flow types implicit and accessCode.');
+        }
+
+        if (in_array($flow, array(self::FLOW_PASSWORD, self::FLOW_APPLICATION, self::FLOW_ACCESS_CODE)) && isset($tokenUrl) === false) {
+            throw new InvalidArgumentException('The tokenUrl is required for flow types password, application and accessCode.');
+        }
+
+        parent::__construct($identifier, self::TYPE_OAUTH2);
+
+        $this->flow = $flow;
+        $this->authorizationUrl = $authorizationUrl;
+        $this->tokenUrl = $tokenUrl;
+        $this->scopes = $scopes;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $securityScheme = parent::jsonSerialize();
+        $securityScheme['flow'] = $this->flow;
+        if (isset($this->authorizationUrl)) {
+            $securityScheme['authorizationUrl'] = $this->authorizationUrl;
+        }
+        if (isset($this->tokenUrl)) {
+            $securityScheme['tokenUrl'] = $this->tokenUrl;
+        }
+        $securityScheme['scopes'] = $this->scopes->jsonSerialize();
+
+        return $securityScheme;
+    }
+}

--- a/src/Security/OAuth2SecurityScheme.php
+++ b/src/Security/OAuth2SecurityScheme.php
@@ -111,4 +111,22 @@ class OAuth2SecurityScheme extends AbstractSecurityScheme
 
         return $securityScheme;
     }
+
+    /**
+     * Returns a new OAuth2SecurityScheme instance.
+     *
+     * @param string      $identifier       the identifier name for the security scheme
+     * @param string      $flow             the flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+     * @param string|null $authorizationUrl the authorization URL to be used for this flow. This SHOULD be in the form of a URL.
+     * @param string|null $tokenUrl         the token URL to be used for this flow. This SHOULD be in the form of a URL.
+     * @param Scopes      $scopes           the available scopes for the OAuth2 security scheme
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return OAuth2SecurityScheme
+     */
+    public static function create($identifier, $flow, $authorizationUrl, $tokenUrl, Scopes $scopes)
+    {
+        return new self($identifier, $flow, $authorizationUrl, $tokenUrl, $scopes);
+    }
 }

--- a/src/Security/Scopes.php
+++ b/src/Security/Scopes.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+use JsonSerializable;
+use stdClass;
+
+/**
+ * Scopes.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class Scopes implements JsonSerializable
+{
+    /**
+     * A list of scopes with a short description.
+     *
+     * @var array
+     */
+    private $scopes = array();
+
+    /**
+     * Adds a scope.
+     *
+     * @param string $name        the name of the scope
+     * @param string $description a short description of the scope
+     *
+     * @return Scopes
+     */
+    public function addScope($name, $description)
+    {
+        $this->scopes[$name] = $description;
+
+        return $this;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array|stdClass
+     */
+    public function jsonSerialize()
+    {
+        if (empty($this->scopes)) {
+            return new stdClass();
+        }
+
+        return $this->scopes;
+    }
+}

--- a/src/Security/Scopes.php
+++ b/src/Security/Scopes.php
@@ -20,6 +20,14 @@ class Scopes implements JsonSerializable
     private $scopes = array();
 
     /**
+     * Returns the names of the scopes.
+     */
+    public function getNames()
+    {
+        return array_keys($this->scopes);
+    }
+
+    /**
      * Adds a scope.
      *
      * @param string $name        the name of the scope

--- a/src/Security/SecurityRequirement.php
+++ b/src/Security/SecurityRequirement.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+use JsonSerializable;
+
+/**
+ * SecurityRequirement.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class SecurityRequirement implements JsonSerializable
+{
+    /**
+     * The identifier name of the related security scheme.
+     *
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * The scopes required for the execution.
+     *
+     * @var Scopes
+     */
+    private $scopes;
+
+    /**
+     * Constructs a new SecurityRequirement instance.
+     *
+     * @param SecuritySchemeInterface|string $identifierOrScheme the related identifier of the security scheme or the security scheme
+     */
+    public function __construct($identifierOrScheme)
+    {
+        if ($identifierOrScheme instanceof SecuritySchemeInterface) {
+            $identifierOrScheme = $identifierOrScheme->getIdentifier();
+        }
+
+        $this->identifier = $identifierOrScheme;
+    }
+
+    /**
+     * Returns the identifier name of the related security scheme.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Sets the scopes required for the execution.
+     *
+     * @param Scopes $scopes
+     *
+     * @return SecurityRequirement
+     */
+    public function setScopes(Scopes $scopes)
+    {
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
+    /**
+     * Returns the representation of this object for JSON encoding.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $securityRequirement = array(
+            $this->identifier => array(),
+        );
+        if (isset($this->scopes)) {
+            $securityRequirement[$this->identifier] = $this->scopes->getNames();
+        }
+
+        return $securityRequirement;
+    }
+
+    /**
+     * Returns a new SecurityRequirement instance.
+     *
+     * @param SecuritySchemeInterface|string $identifierOrScheme
+     *
+     * @return SecurityRequirement
+     */
+    public static function create($identifierOrScheme)
+    {
+        return new self($identifierOrScheme);
+    }
+}

--- a/src/Security/SecuritySchemeInterface.php
+++ b/src/Security/SecuritySchemeInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Security;
+
+use JsonSerializable;
+
+/**
+ * SecuritySchemeInterface.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+interface SecuritySchemeInterface extends JsonSerializable
+{
+    /**
+     * @var string
+     */
+    const TYPE_BASIC = 'basic';
+
+    /**
+     * @var string
+     */
+    const TYPE_API_KEY = 'apiKey';
+
+    /**
+     * @var string
+     */
+    const TYPE_OAUTH2 = 'oauth2';
+
+    /**
+     * Returns the identifier name for the security scheme.
+     *
+     * @return string
+     */
+    public function getIdentifier();
+}

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -5,6 +5,7 @@ namespace ConnectHolland\OpenAPISpecificationGenerator;
 use ConnectHolland\OpenAPISpecificationGenerator\Info\Info;
 use ConnectHolland\OpenAPISpecificationGenerator\Path\PathItem;
 use ConnectHolland\OpenAPISpecificationGenerator\Schema\SchemaElementInterface;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface;
 use JsonSerializable;
 use stdClass;
 
@@ -77,6 +78,13 @@ class Specification implements JsonSerializable
      * @var SchemaElementInterface[]
      */
     private $definitions = array();
+
+    /**
+     * The security scheme definitions that can be used across the specification.
+     *
+     * @var SecuritySchemeInterface[]
+     */
+    private $securityDefinitions = array();
 
     /**
      * Additional external documentation.
@@ -196,6 +204,20 @@ class Specification implements JsonSerializable
     }
 
     /**
+     * Adds a security scheme definition that can be used across the specification.
+     *
+     * @param SecuritySchemeInterface $securityScheme
+     *
+     * @return Specification
+     */
+    public function addSecurityDefinition(SecuritySchemeInterface $securityScheme)
+    {
+        $this->securityDefinitions[] = $securityScheme;
+
+        return $this;
+    }
+
+    /**
      * Sets the additional external documentation.
      *
      * @param ExternalDocumentation $externalDocumentation
@@ -247,6 +269,12 @@ class Specification implements JsonSerializable
             $specification['definitions'] = array();
             foreach ($this->definitions as $definition => $schema) {
                 $specification['definitions'][$definition] = $schema->jsonSerialize();
+            }
+        }
+
+        if (empty($this->securityDefinitions) === false) {
+            foreach ($this->securityDefinitions as $securityScheme) {
+                $specification['securityDefinitions'][$securityScheme->getIdentifier()] = $securityScheme->jsonSerialize();
             }
         }
 

--- a/tests/Path/OperationTest.php
+++ b/tests/Path/OperationTest.php
@@ -153,6 +153,34 @@ class OperationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Operation::setSecurityRequirements sets the instance property to an empty array and returns the Operation instance.
+     */
+    public function testSetSecurityRequirementsEmpty()
+    {
+        $operation = $this->operation->setSecurityRequirements(array());
+
+        $this->assertSame($this->operation, $operation);
+        $this->assertAttributeSame(array(), 'securityRequirements', $operation);
+    }
+
+    /**
+     * Tests if Operation::setSecurityRequirements sets the instance property and returns the Operation instance.
+     *
+     * @depends testSetSecurityRequirementsEmpty
+     */
+    public function testSetSecurityRequirements()
+    {
+        $securityRequirementMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\SecurityRequirement')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $operation = $this->operation->setSecurityRequirements(array($securityRequirementMock));
+
+        $this->assertSame($this->operation, $operation);
+        $this->assertAttributeSame(array($securityRequirementMock), 'securityRequirements', $operation);
+    }
+
+    /**
      * Tests if Operation::addParameter adds a ParameterInterface to the parameters property and returns the Operation instance.
      */
     public function testAddParameter()
@@ -188,6 +216,19 @@ class OperationTest extends PHPUnit_Framework_TestCase
             ->method('jsonSerialize')
             ->willReturn(array('url' => 'https://documentation.connectholland.nl'));
 
+        $securityRequirementMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\SecurityRequirement')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $securityRequirementMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'auth' => array(
+                        'api_key' => array(),
+                    ),
+                )
+            );
+
         $this->operation->setOperationId('test-operation');
         $this->operation->setSummary('A summary.');
         $this->operation->setDescription('A description.');
@@ -198,6 +239,7 @@ class OperationTest extends PHPUnit_Framework_TestCase
         $this->operation->setDeprecated(true);
         $this->operation->addParameter($parameterMock);
         $this->operation->setExternalDocumentation($externalDocumentationMock);
+        $this->operation->setSecurityRequirements(array($securityRequirementMock));
 
         $expectedResult = array(
             'operationId' => 'test-operation',
@@ -221,6 +263,13 @@ class OperationTest extends PHPUnit_Framework_TestCase
             'schemes' => array('https'),
             'deprecated' => true,
             'tags' => array('tag'),
+            'security' => array(
+                array(
+                    'auth' => array(
+                        'api_key' => array(),
+                    ),
+                ),
+            ),
         );
 
         $this->assertEquals($expectedResult, $this->operation->jsonSerialize());
@@ -250,8 +299,9 @@ class OperationTest extends PHPUnit_Framework_TestCase
         $this->operation->setTags(array('tag'));
         $this->operation->setDeprecated(true);
         $this->operation->addParameter($parameterMock);
+        $this->operation->setSecurityRequirements(array());
 
-        $expectedResult = '{"operationId":"test-operation","summary":"A summary.","description":"A description.","consumes":["application\/json"],"produces":["application\/json"],"parameters":[{"name":"parameterName","in":"body","schema":{"type":"string"}}],"responses":{},"schemes":["https"],"deprecated":true,"tags":["tag"]}';
+        $expectedResult = '{"operationId":"test-operation","summary":"A summary.","description":"A description.","consumes":["application\/json"],"produces":["application\/json"],"parameters":[{"name":"parameterName","in":"body","schema":{"type":"string"}}],"responses":{},"schemes":["https"],"deprecated":true,"tags":["tag"],"security":[]}';
 
         $this->assertJsonStringEqualsJsonString($expectedResult, json_encode($this->operation));
     }

--- a/tests/Security/AbstractSecuritySchemeTest.php
+++ b/tests/Security/AbstractSecuritySchemeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\ApiKeySecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\BasicSecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\OAuth2SecurityScheme;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * AbstractSecuritySchemeTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+abstract class AbstractSecuritySchemeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The security scheme instance being tested.
+     *
+     * @var BasicSecurityScheme|ApiKeySecurityScheme|OAuth2SecurityScheme
+     */
+    protected $securityScheme;
+
+    /**
+     * Tests if AbstractSecurityScheme::getIdentifier returns the identifier set during construction.
+     */
+    public function testGetIdentifier()
+    {
+        $this->assertSame('foo', $this->securityScheme->getIdentifier());
+    }
+
+    /**
+     * Tests if AbstractSecurityScheme::setDescription sets the instance property and returns the AbstractSecurityScheme instance.
+     */
+    public function testSetDescription()
+    {
+        $securityScheme = $this->securityScheme->setDescription('A description');
+
+        $this->assertSame($this->securityScheme, $securityScheme);
+        $this->assertAttributeSame('A description', 'description', $securityScheme);
+    }
+}

--- a/tests/Security/ApiKeySecuritySchemeTest.php
+++ b/tests/Security/ApiKeySecuritySchemeTest.php
@@ -59,4 +59,18 @@ class ApiKeySecuritySchemeTest extends AbstractSecuritySchemeTest
 
         $this->assertEquals($expectedResult, $this->securityScheme->jsonSerialize());
     }
+
+    /**
+     * Tests if ApiKeySecurityScheme::create returns a new ApiKeySecurityScheme instance and sets the instance properties.
+     */
+    public function testCreate()
+    {
+        $securityScheme = ApiKeySecurityScheme::create('foo', 'X-Test-Header', ApiKeySecurityScheme::IN_HEADER);
+
+        $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Security\ApiKeySecurityScheme', $securityScheme);
+        $this->assertAttributeSame('foo', 'identifier', $this->securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_API_KEY, 'type', $this->securityScheme);
+        $this->assertAttributeSame('X-Test-Header', 'name', $this->securityScheme);
+        $this->assertAttributeSame(ApiKeySecurityScheme::IN_HEADER, 'in', $this->securityScheme);
+    }
 }

--- a/tests/Security/ApiKeySecuritySchemeTest.php
+++ b/tests/Security/ApiKeySecuritySchemeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\ApiKeySecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface;
+
+/**
+ * ApiKeySecuritySchemeTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ApiKeySecuritySchemeTest extends AbstractSecuritySchemeTest
+{
+    /**
+     * Creates a new ApiKeySecurityScheme instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->securityScheme = new ApiKeySecurityScheme('foo', 'X-Test-Header', ApiKeySecurityScheme::IN_HEADER);
+    }
+
+    /**
+     * Tests if constructing a new ApiKeySecurityScheme instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('foo', 'identifier', $this->securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_API_KEY, 'type', $this->securityScheme);
+        $this->assertAttributeSame('X-Test-Header', 'name', $this->securityScheme);
+        $this->assertAttributeSame(ApiKeySecurityScheme::IN_HEADER, 'in', $this->securityScheme);
+    }
+
+    /**
+     * Tests if constructing a new ApiKeySecurityScheme instance with invalid $in argument throws an InvalidArgumentException.
+     */
+    public function testConstuctThrowsInvalidArgumentExceptionForInvalidInType()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Supplied SecurityScheme $in is not of type query or header.');
+
+        new ApiKeySecurityScheme('foo', 'X-Test-Header', 'invalid');
+    }
+
+    /**
+     * Tests if ApiKeySecurityScheme::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $this->securityScheme->setDescription('A description');
+
+        $expectedResult = array(
+            'type' => 'apiKey',
+            'description' => 'A description',
+            'name' => 'X-Test-Header',
+            'in' => 'header',
+        );
+
+        $this->assertEquals($expectedResult, $this->securityScheme->jsonSerialize());
+    }
+}

--- a/tests/Security/BasicSecuritySchemeTest.php
+++ b/tests/Security/BasicSecuritySchemeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\BasicSecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface;
+
+/**
+ * BasicSecuritySchemeTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class BasicSecuritySchemeTest extends AbstractSecuritySchemeTest
+{
+    /**
+     * Creates a new BasicSecurityScheme instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->securityScheme = new BasicSecurityScheme('foo');
+    }
+
+    /**
+     * Tests if constructing a new BasicSecurityScheme instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('foo', 'identifier', $this->securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_BASIC, 'type', $this->securityScheme);
+    }
+
+    /**
+     * Tests if BasicSecurityScheme::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $this->securityScheme->setDescription('A description');
+
+        $expectedResult = array(
+            'type' => 'basic',
+            'description' => 'A description',
+        );
+
+        $this->assertEquals($expectedResult, $this->securityScheme->jsonSerialize());
+    }
+}

--- a/tests/Security/BasicSecuritySchemeTest.php
+++ b/tests/Security/BasicSecuritySchemeTest.php
@@ -45,4 +45,16 @@ class BasicSecuritySchemeTest extends AbstractSecuritySchemeTest
 
         $this->assertEquals($expectedResult, $this->securityScheme->jsonSerialize());
     }
+
+    /**
+     * Tests if BasicSecurityScheme::create returns a new BasicSecurityScheme instance and sets the instance properties.
+     */
+    public function testCreate()
+    {
+        $securityScheme = BasicSecurityScheme::create('foo');
+
+        $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Security\BasicSecurityScheme', $securityScheme);
+        $this->assertAttributeSame('foo', 'identifier', $securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_BASIC, 'type', $securityScheme);
+    }
 }

--- a/tests/Security/OAuth2SecuritySchemeTest.php
+++ b/tests/Security/OAuth2SecuritySchemeTest.php
@@ -188,6 +188,28 @@ class OAuth2SecuritySchemeTest extends AbstractSecuritySchemeTest
     }
 
     /**
+     * Tests if OAuth2SecurityScheme::create returns a new OAuth2SecurityScheme instance and sets the instance properties.
+     */
+    public function testCreate()
+    {
+        $securityScheme = OAuth2SecurityScheme::create(
+            'foo',
+            OAuth2SecurityScheme::FLOW_ACCESS_CODE,
+            'https://github.com/login/oauth/authorize',
+            'https://github.com/login/oauth/access_token',
+            $this->scopesMock
+        );
+
+        $this->assertInstanceOf('ConnectHolland\OpenAPISpecificationGenerator\Security\OAuth2SecurityScheme', $securityScheme);
+        $this->assertAttributeSame('foo', 'identifier', $this->securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_OAUTH2, 'type', $this->securityScheme);
+        $this->assertAttributeSame(OAuth2SecurityScheme::FLOW_ACCESS_CODE, 'flow', $this->securityScheme);
+        $this->assertAttributeSame('https://github.com/login/oauth/authorize', 'authorizationUrl', $this->securityScheme);
+        $this->assertAttributeSame('https://github.com/login/oauth/access_token', 'tokenUrl', $this->securityScheme);
+        $this->assertAttributeSame($this->scopesMock, 'scopes', $this->securityScheme);
+    }
+
+    /**
      * Returns a list with cases that should throw an InvalidArgumentException with specific exception message during construction of a OAuth2SecurityScheme.
      *
      * @return array

--- a/tests/Security/OAuth2SecuritySchemeTest.php
+++ b/tests/Security/OAuth2SecuritySchemeTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\OAuth2SecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface;
+use stdClass;
+
+/**
+ * OAuth2SecuritySchemeTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class OAuth2SecuritySchemeTest extends AbstractSecuritySchemeTest
+{
+    /**
+     * The Scopes instance mock used for testing.
+     *
+     * @var Scopes
+     */
+    private $scopesMock;
+
+    /**
+     * Creates a new OAuth2SecurityScheme instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->scopesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->securityScheme = new OAuth2SecurityScheme(
+            'foo',
+            OAuth2SecurityScheme::FLOW_ACCESS_CODE,
+            'https://github.com/login/oauth/authorize',
+            'https://github.com/login/oauth/access_token',
+            $this->scopesMock
+        );
+    }
+
+    /**
+     * Tests if constructing a new OAuth2SecurityScheme instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('foo', 'identifier', $this->securityScheme);
+        $this->assertAttributeSame(SecuritySchemeInterface::TYPE_OAUTH2, 'type', $this->securityScheme);
+        $this->assertAttributeSame(OAuth2SecurityScheme::FLOW_ACCESS_CODE, 'flow', $this->securityScheme);
+        $this->assertAttributeSame('https://github.com/login/oauth/authorize', 'authorizationUrl', $this->securityScheme);
+        $this->assertAttributeSame('https://github.com/login/oauth/access_token', 'tokenUrl', $this->securityScheme);
+        $this->assertAttributeSame($this->scopesMock, 'scopes', $this->securityScheme);
+    }
+
+    /**
+     * Tests if constructing a new OAuth2SecurityScheme instance with
+     * invalid combinations of $flow, $authorizationUrl and $tokenUrl
+     * throws an InvalidArgumentException.
+     *
+     * @dataProvider provideConstructThrowsInvalidArgumentExceptionCases
+     *
+     * @param string      $flow
+     * @param string|null $authorizationUrl
+     * @param string      $expectedExceptionMessage
+     */
+    public function testConstructThrowsInvalidArgumentException($flow, $authorizationUrl, $expectedExceptionMessage)
+    {
+        $this->setExpectedException('InvalidArgumentException', $expectedExceptionMessage);
+
+        new OAuth2SecurityScheme('foo', $flow, $authorizationUrl, null, $this->scopesMock);
+    }
+
+    /**
+     * Tests if OAuth2SecurityScheme::jsonSerialize returns the expected result.
+     */
+    public function testJsonSerialize()
+    {
+        $this->scopesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
+
+        $this->securityScheme->setDescription('A description');
+
+        $expectedResult = array(
+            'type' => 'oauth2',
+            'description' => 'A description',
+            'flow' => 'accessCode',
+            'authorizationUrl' => 'https://github.com/login/oauth/authorize',
+            'tokenUrl' => 'https://github.com/login/oauth/access_token',
+            'scopes' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $this->securityScheme->jsonSerialize());
+    }
+
+    /**
+     * Tests if OAuth2SecurityScheme::jsonSerialize returns the expected result through the json_encode function.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeThroughJsonEncode()
+    {
+        $this->scopesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(
+                array(
+                    'write:pets' => 'modify pets in your account',
+                    'read:pets' => 'read your pets',
+                )
+            );
+
+        $this->securityScheme->setDescription('A description');
+
+        $expectedResult = '{"type":"oauth2","description":"A description","flow":"accessCode","authorizationUrl":"https://github.com/login/oauth/authorize","tokenUrl":"https://github.com/login/oauth/access_token","scopes":{"write:pets":"modify pets in your account","read:pets":"read your pets"}}';
+
+        $this->assertEquals($expectedResult, json_encode($this->securityScheme, JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Tests if OAuth2SecurityScheme::jsonSerialize returns the expected result for "implicit" flow.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeImplicit()
+    {
+        $this->scopesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
+
+        $securityScheme = new OAuth2SecurityScheme('foo', OAuth2SecurityScheme::FLOW_IMPLICIT, 'https://github.com/login/oauth/authorize', null, $this->scopesMock);
+
+        $expectedResult = array(
+            'type' => 'oauth2',
+            'flow' => 'implicit',
+            'authorizationUrl' => 'https://github.com/login/oauth/authorize',
+            'scopes' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $securityScheme->jsonSerialize());
+    }
+
+    /**
+     * Tests if OAuth2SecurityScheme::jsonSerialize returns the expected result for "password" flow.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializePassword()
+    {
+        $this->scopesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
+
+        $securityScheme = new OAuth2SecurityScheme('foo', OAuth2SecurityScheme::FLOW_PASSWORD, null, 'https://github.com/login/oauth/access_token', $this->scopesMock);
+
+        $expectedResult = array(
+            'type' => 'oauth2',
+            'flow' => 'password',
+            'tokenUrl' => 'https://github.com/login/oauth/access_token',
+            'scopes' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $securityScheme->jsonSerialize());
+    }
+
+    /**
+     * Tests if OAuth2SecurityScheme::jsonSerialize returns the expected result for "application" flow.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeApplication()
+    {
+        $this->scopesMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(new stdClass());
+
+        $securityScheme = new OAuth2SecurityScheme('foo', OAuth2SecurityScheme::FLOW_APPLICATION, null, 'https://github.com/login/oauth/access_token', $this->scopesMock);
+
+        $expectedResult = array(
+            'type' => 'oauth2',
+            'flow' => 'application',
+            'tokenUrl' => 'https://github.com/login/oauth/access_token',
+            'scopes' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $securityScheme->jsonSerialize());
+    }
+
+    /**
+     * Returns a list with cases that should throw an InvalidArgumentException with specific exception message during construction of a OAuth2SecurityScheme.
+     *
+     * @return array
+     */
+    public function provideConstructThrowsInvalidArgumentExceptionCases()
+    {
+        $expectedFlowExceptionMessage = 'Supplied SecurityScheme flow is not of type implicit, password, application or accessCode.';
+        $expectedAuthorizationUrlExceptionMessage = 'The authorizationUrl is required for flow types implicit and accessCode.';
+        $expectedTokenUrlExceptionMessage = 'The tokenUrl is required for flow types password, application and accessCode.';
+
+        return array(
+            array(
+                'invalid',
+                'https://github.com/login/oauth/authorize',
+                $expectedFlowExceptionMessage,
+            ),
+            array(
+                OAuth2SecurityScheme::FLOW_IMPLICIT,
+                null,
+                $expectedAuthorizationUrlExceptionMessage,
+            ),
+            array(
+                OAuth2SecurityScheme::FLOW_ACCESS_CODE,
+                null,
+                $expectedAuthorizationUrlExceptionMessage,
+            ),
+            array(
+                OAuth2SecurityScheme::FLOW_PASSWORD,
+                null,
+                $expectedTokenUrlExceptionMessage,
+            ),
+            array(
+                OAuth2SecurityScheme::FLOW_APPLICATION,
+                null,
+                $expectedTokenUrlExceptionMessage,
+            ),
+            array(
+                OAuth2SecurityScheme::FLOW_ACCESS_CODE,
+                'https://github.com/login/oauth/authorize',
+                $expectedTokenUrlExceptionMessage,
+            ),
+        );
+    }
+}

--- a/tests/Security/ScopesTest.php
+++ b/tests/Security/ScopesTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+/**
+ * ScopesTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ScopesTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The Scopes instance being tested.
+     *
+     * @var Scopes
+     */
+    private $scopes;
+
+    /**
+     * Creates a new Scopes instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->scopes = new Scopes();
+    }
+
+    /**
+     * Tests if Scopes::addScope adds the scope to the scopes instance property and returns the Scopes instance.
+     */
+    public function testAddScope()
+    {
+        $scopes = $this->scopes->addScope('write:pets', 'modify pets in your account');
+
+        $this->assertSame($this->scopes, $scopes);
+        $this->assertAttributeSame(
+            array(
+                'write:pets' => 'modify pets in your account',
+            ),
+            'scopes',
+            $scopes
+        );
+    }
+
+    /**
+     * Tests if Scopes::jsonSerialize returns the expected result when empty.
+     */
+    public function testJsonSerializeEmpty()
+    {
+        $this->assertEquals(new stdClass(), $this->scopes->jsonSerialize());
+    }
+
+    /**
+     * Tests if Scopes::jsonSerialize returns the expected result.
+     *
+     * @depends testAddScope
+     */
+    public function testJsonSerialize()
+    {
+        $this->scopes->addScope('write:pets', 'modify pets in your account');
+        $this->scopes->addScope('read:pets', 'read your pets');
+
+        $this->assertSame(
+            array(
+                'write:pets' => 'modify pets in your account',
+                'read:pets' => 'read your pets',
+            ),
+            $this->scopes->jsonSerialize()
+        );
+    }
+}

--- a/tests/Security/ScopesTest.php
+++ b/tests/Security/ScopesTest.php
@@ -48,6 +48,18 @@ class ScopesTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Scopes::getNames returns the names of the added scopes.
+     *
+     * @depends testAddScope
+     */
+    public function testGetNames()
+    {
+        $this->scopes->addScope('write:pets', 'modify pets in your account');
+
+        $this->assertSame(array('write:pets'), $this->scopes->getNames());
+    }
+
+    /**
      * Tests if Scopes::jsonSerialize returns the expected result when empty.
      */
     public function testJsonSerializeEmpty()

--- a/tests/Security/SecurityRequirementTest.php
+++ b/tests/Security/SecurityRequirementTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace ConnectHolland\OpenAPISpecificationGenerator\Test\Security;
+
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecurityRequirement;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * SecurityRequirementTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class SecurityRequirementTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The SecurityRequirement instance being tested.
+     *
+     * @var SecurityRequirement
+     */
+    private $securityRequirement;
+
+    /**
+     * Creates a SecurityRequirement instance for testing.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->securityRequirement = new SecurityRequirement('auth');
+    }
+
+    /**
+     * Tests if constructing a new SecurityRequirement instance sets
+     * the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame('auth', 'identifier', $this->securityRequirement);
+    }
+
+    /**
+     * Tests if constructing a new SecurityRequirement instance with
+     * SecuritySchemeInterface instance sets the identifier
+     * to the instance property.
+     *
+     * @depends testConstruct
+     */
+    public function testConstructWithSecurityScheme()
+    {
+        $securitySchemeMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface')
+            ->getMock();
+        $securitySchemeMock->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('auth');
+
+        $securityRequirement = new SecurityRequirement($securitySchemeMock);
+
+        $this->assertAttributeSame('auth', 'identifier', $securityRequirement);
+    }
+
+    /**
+     * Tests if SecurityRequirement::getIdentifier returns the identifier
+     * set during construction.
+     */
+    public function testGetIdentifier()
+    {
+        $this->assertSame('auth', $this->securityRequirement->getIdentifier());
+    }
+
+    /**
+     * Tests if SecurityRequirement::setScopes sets the instance property
+     * and returns the SecurityRequirement instance.
+     */
+    public function testSetScopes()
+    {
+        $scopesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $securityRequirement = $this->securityRequirement->setScopes($scopesMock);
+
+        $this->assertSame($this->securityRequirement, $securityRequirement);
+        $this->assertAttributeSame($scopesMock, 'scopes', $securityRequirement);
+    }
+
+    /**
+     * Tests if SecurityRequirement::jsonSerialize returns the expected result.
+     *
+     * @depends testSetScopes
+     */
+    public function testJsonSerialize()
+    {
+        $scopesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $scopesMock->expects($this->once())
+            ->method('getNames')
+            ->willReturn(array('write:pets'));
+
+        $this->securityRequirement->setScopes($scopesMock);
+
+        $expectedResult = array(
+            'auth' => array(
+                'write:pets',
+            ),
+        );
+
+        $this->assertEquals($expectedResult, $this->securityRequirement->jsonSerialize());
+    }
+
+    /**
+     * Tests if SecurityRequirement::jsonSerialize returns the expected result.
+     *
+     * @depends testJsonSerialize
+     */
+    public function testJsonSerializeThoughJsonEncode()
+    {
+        $scopesMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\Scopes')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $scopesMock->expects($this->once())
+            ->method('getNames')
+            ->willReturn(array('write:pets'));
+
+        $this->securityRequirement->setScopes($scopesMock);
+
+        $expectedResult = '{"auth":["write:pets"]}';
+
+        $this->assertEquals($expectedResult, json_encode($this->securityRequirement));
+    }
+
+    /**
+     * Tests if SecurityRequirement::create returns a new
+     * SecurityRequirement instance and sets the instance properties.
+     */
+    public function testCreate()
+    {
+        $securityRequirement = SecurityRequirement::create('auth');
+
+        $this->assertAttributeSame('auth', 'identifier', $securityRequirement);
+    }
+}

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -152,6 +152,20 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Specification::addSecurityDefinition adds the SecuritySchemeInterface instance to the instance property and returns the Specification instance.
+     */
+    public function testAddSecurityDefinition()
+    {
+        $securitySchemeMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface')
+            ->getMock();
+
+        $specification = $this->specification->addSecurityDefinition($securitySchemeMock);
+
+        $this->assertSame($this->specification, $specification);
+        $this->assertAttributeSame(array($securitySchemeMock), 'securityDefinitions', $specification);
+    }
+
+    /**
      * Tests if Specification::setExternalDocumentation sets the ExternalDocumentation instance on instance property and returns the Specification instance.
      */
     public function testSetExternalDocumentation()
@@ -182,6 +196,43 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
                 'version' => '1.0',
             ),
             'paths' => new stdClass(),
+        );
+
+        $this->assertEquals($expectedResult, $this->specification->jsonSerialize());
+    }
+
+    /**
+     * Tests if Specification::jsonSerialize with security definitions added returns the expected result.
+     */
+    public function testJsonSerializeWithSecurityDefinitions()
+    {
+        $this->infoMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('title' => 'API', 'version' => '1.0'));
+
+        $securitySchemeMock = $this->getMockBuilder('ConnectHolland\OpenAPISpecificationGenerator\Security\SecuritySchemeInterface')
+            ->getMock();
+        $securitySchemeMock->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('basic_auth');
+        $securitySchemeMock->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn(array('type' => 'basic'));
+
+        $this->specification->addSecurityDefinition($securitySchemeMock);
+
+        $expectedResult = array(
+            'swagger' => '2.0',
+            'info' => array(
+                'title' => 'API',
+                'version' => '1.0',
+            ),
+            'paths' => new stdClass(),
+            'securityDefinitions' => array(
+                'basic_auth' => array(
+                    'type' => 'basic',
+                ),
+            ),
         );
 
         $this->assertEquals($expectedResult, $this->specification->jsonSerialize());

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -20,6 +20,8 @@ use ConnectHolland\OpenAPISpecificationGenerator\Schema\Primitive\IntegerElement
 use ConnectHolland\OpenAPISpecificationGenerator\Schema\Primitive\LongElement;
 use ConnectHolland\OpenAPISpecificationGenerator\Schema\Primitive\StringElement;
 use ConnectHolland\OpenAPISpecificationGenerator\Schema\ReferenceElement;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\BasicSecurityScheme;
+use ConnectHolland\OpenAPISpecificationGenerator\Security\SecurityRequirement;
 use ConnectHolland\OpenAPISpecificationGenerator\Specification;
 use PHPUnit_Framework_TestCase;
 use stdClass;
@@ -836,5 +838,44 @@ class SpecificationTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertJsonStringEqualsJsonFile(__DIR__.'/fixtures/petstore-simple-swagger.json', json_encode($specification, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Tests if Specification::jsonSerialize returns the expected JSON encoded result through the json_encode function with the Basic Auth specification example.
+     *
+     * @see http://editor.swagger.io/ The editor containing the specification example
+     *
+     * @depends testJsonSerializeThroughJsonEncode
+     */
+    public function testJsonSerializeThroughJsonEncodeWithBasicAuthSpecificationExample()
+    {
+        $info = Info::create('Basic Auth Example', '1.0.0')
+            ->setDescription("An example for how to use Basic Auth with Swagger.\nServer code is available [here](https://github.com/mohsen1/basic-auth-server). It's running on Heroku.\n\n**User Name and Password**\n* User Name: `user`\n* Password: `pass`\n");
+
+        $securityScheme = BasicSecurityScheme::create('basicAuth')
+            ->setDescription('HTTP Basic Authentication. Works over `HTTP` and `HTTPS`');
+
+        $specification = Specification::create($info)
+            ->setHost('basic-auth-server.herokuapp.com')
+            ->setSchemes(array('http', 'https'))
+            ->addSecurityDefinition($securityScheme);
+
+        $specification->setPath(
+            '/',
+            PathItem::create()
+                ->setGet(
+                    Operation::create(
+                        Responses::create()
+                            ->setResponse(
+                                Response::HTTP_OK,
+                                Response::create('Will send `Authenticated` if authentication is succesful, otherwise it will send `Unauthorized`')
+                            )
+                    )->setSecurityRequirements(
+                        array(SecurityRequirement::create($securityScheme))
+                    )
+                )
+        );
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__.'/fixtures/basic-auth.json', json_encode($specification, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/tests/fixtures/basic-auth.json
+++ b/tests/fixtures/basic-auth.json
@@ -1,0 +1,35 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Basic Auth Example",
+        "version": "1.0.0",
+        "description": "An example for how to use Basic Auth with Swagger.\nServer code is available [here](https://github.com/mohsen1/basic-auth-server). It's running on Heroku.\n\n**User Name and Password**\n* User Name: `user`\n* Password: `pass`\n"
+    },
+    "host": "basic-auth-server.herokuapp.com",
+    "schemes": [
+        "http",
+        "https"
+    ],
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Will send `Authenticated` if authentication is succesful, otherwise it will send `Unauthorized`"
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": []
+                    }
+                ]
+            }
+        }
+    },
+    "securityDefinitions": {
+        "basicAuth": {
+            "type": "basic",
+            "description": "HTTP Basic Authentication. Works over `HTTP` and `HTTPS`"
+        }
+    }
+}


### PR DESCRIPTION
Adds the security implementation of the [Swagger / OpenAPI v2 specification](http://swagger.io/specification/#securityRequirementObject).

Task of #3.